### PR TITLE
fix: 2本のフォークを持ったときに死ぬ場合、両方のフォークを下ろすように修正

### DIFF
--- a/philo/Makefile
+++ b/philo/Makefile
@@ -1,6 +1,6 @@
 NAME 		:= philo
 CC			:=	gcc
-CFLAGS		:=	-Wall -Wextra -Werror -g -pthread -fsanitize=thread
+CFLAGS		:=	-Wall -Wextra -Werror -g -pthread
 
 HEADERS		=	.
 

--- a/philo/philo.h
+++ b/philo/philo.h
@@ -91,8 +91,8 @@ bool				print_log(const t_philosopher *philosopher, t_state state);
 bool				get_fork_state(t_fork *fork);
 void				set_fork_state(t_fork *fork, bool is_taken);
 int					get_fork_id(int id, int n);
-bool				take_forks(t_philosopher *philosopher, t_fork *forks);
-bool				put_forks(t_philosopher *philosopher, t_fork *forks);
+bool				take_forks(t_philosopher *philosopher);
+bool				put_forks(t_philosopher *philosopher);
 void				sleep_in_ms(size_t ms);
 
 #endif

--- a/philo/simulate_single_philosopher.c
+++ b/philo/simulate_single_philosopher.c
@@ -6,13 +6,13 @@ bool	eat(t_philosopher *philosopher)
 {
 	if (!print_log(philosopher, EATING))
 	{
-		put_forks(philosopher, philosopher->vars->forks);
+		put_forks(philosopher);
 		return (false);
 	}
 	set_last_ate_at(philosopher, get_time_ms());
 	sleep_in_ms(philosopher->args->eat_ms);
 	philosopher->eat_count++;
-	return (put_forks(philosopher, philosopher->vars->forks));
+	return (put_forks(philosopher));
 }
 
 bool go_to_sleep(t_philosopher *philosopher)
@@ -41,7 +41,7 @@ void *simulate_single_philosopher(void *philosopher_ptr)
 		usleep(1500);
 	while (true)
 	{
-		if (!take_forks(philosopher, philosopher->vars->forks))
+		if (!take_forks(philosopher))
 			return (NULL);
 		if (!eat(philosopher))
 			return (NULL);


### PR DESCRIPTION

フォークを2本持った際に、死んだ場合は1本だけおろしていた
ただ、そうするとずっとスレッドが終了しない
両方のフォークを下ろすように修正した